### PR TITLE
Covid: update x axis type so correct format appears

### DIFF
--- a/covid-19/active-cases/js/area.js
+++ b/covid-19/active-cases/js/area.js
@@ -55,11 +55,11 @@ $(function () {
     tooltip: {
       useHTML: true,
       formatter: function () {
-        var gmtDate = new Date(this.x)
+        let gmtDate = new Date(this.x)
         let dateObj = new Date(gmtDate.getTime() - gmtDate.getTimezoneOffset() * -60000)
         const dtf = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric', timeZone: 'America/New_York' })
         const [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(dateObj)
-        var formattedDate = `${mo} ${da}, ${ye}`
+        let formattedDate = `${mo} ${da}, ${ye}`
 
         let total = 0
         let lines = this.points.map((point, i) => {

--- a/covid-19/military-cases/js/area.js
+++ b/covid-19/military-cases/js/area.js
@@ -35,6 +35,7 @@ $(function () {
     },
     // xAxis
     xAxis: {
+      type: 'datetime',
       dateTimeLabelFormats: {
         day: '%e-%b'
       }
@@ -54,11 +55,11 @@ $(function () {
     tooltip: {
       useHTML: true,
       formatter: function () {
-        var gmtDate = new Date(this.x)
+        let gmtDate = new Date(this.x)
         let dateObj = new Date(gmtDate.getTime() - gmtDate.getTimezoneOffset() * -60000)
         const dtf = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'short', day: 'numeric' })
         const [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(dateObj)
-        var formattedDate = `${mo} ${da}, ${ye}`
+        let formattedDate = `${mo} ${da}, ${ye}`
 
         let total = 0
         let lines = this.points.map((point, i) => {

--- a/covid-19/natl-guard-activations/js/area.js
+++ b/covid-19/natl-guard-activations/js/area.js
@@ -37,6 +37,7 @@ $(function () {
     },
     // xAxis
     xAxis: {
+      type: 'datetime',
       dateTimeLabelFormats: {
         day: '%e-%b'
       }

--- a/covid-19/total-dod/js/spline.js
+++ b/covid-19/total-dod/js/spline.js
@@ -37,6 +37,7 @@ Highcharts.chart("hcContainer", {
   },
   // xAxis
   xAxis: {
+    type: 'datetime',
     dateTimeLabelFormats: {
       day: '%e-%b'
     }
@@ -90,10 +91,11 @@ Highcharts.chart("hcContainer", {
         //   total += serie.points[serie.points.length - 1].y
         // })
         let secDate = s[0].points[s[0].points.length - 1].x
-        var dateObj = new Date(secDate);
+        let gmtDate = new Date(secDate)
+        let dateObj = new Date(gmtDate.getTime() - gmtDate.getTimezoneOffset() * -60000)
         const dtf = new Intl.DateTimeFormat('en-US', { year: 'numeric', month: 'numeric', day: 'numeric' })
         const [{ value: mo }, , { value: da }, , { value: ye }] = dtf.formatToParts(dateObj)
-        var formattedDate = `${mo}/${da}/${ye}`
+        let formattedDate = `${mo}/${da}/${ye}`
         return 'Total Cases as of ' + formattedDate + ': <b>' + Highcharts.numberFormat(total, 0, '.', ',') + '</b>'
       }
     }],


### PR DESCRIPTION
Changed x axis type to datetime, as this is required for the correct format to appear.  Also, updated the date in the annotation on the total DoD cases chart.